### PR TITLE
Fix stacking lines in tooltips when scrolling

### DIFF
--- a/WhatsTrainingUI.lua
+++ b/WhatsTrainingUI.lua
@@ -17,6 +17,7 @@ local TAB_TEXTURE_FILEID = GetFileIDFromPath(
 local tooltip = CreateFrame("GameTooltip", "WhatsTrainingTooltip", UIParent,
                             "GameTooltipTemplate")
 local function setTooltip(spellInfo)
+    tooltip:ClearLines()
     if (spellInfo.isItem) then
         tooltip:SetItemByID(spellInfo.id)
     elseif (spellInfo.id) then


### PR DESCRIPTION
When you scroll or quickly move between lines so does the tooltip not reset properly, making it stack more and more lines of old data.
This resets the tooltip every time you hover over a line and prevent the tooltip stacking when scrolling.